### PR TITLE
updating node image from 16 to 21 and fixed syncing package.json and package-lock.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # define base image
-FROM node:16.17.0-bullseye-slim
+FROM node:21.6.1-bullseye-slim
 
 # download dumb-init
 RUN apt-get update && apt-get install -y --no-install-recommends dumb-init

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR /usr/src/app
 COPY --chown=node:node . /usr/src/app
 
 # install dependencies
+RUN npm install
 RUN npm ci --only=production
 
 # run your app

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@discordjs/rest": "^1.5.0",
     "axios": "0.27.2",
     "bad-words": "^3.0.4",
-    "canvas": "^2.10.1",
+    "canvas": "^2.11.2",
     "chalk": "^4.1.0",
     "cheerio": "1.0.0-rc.12",
     "discord-api-types": "^0.37.55",


### PR DESCRIPTION
npm ERR! `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.