### PR TITLE
Fixing being able to get the bot in your party without fragbot enabled

### DIFF
--- a/src/minecraft/commands/warpoutCommand.js
+++ b/src/minecraft/commands/warpoutCommand.js
@@ -108,7 +108,7 @@ class warpoutCommand extends minecraftCommand {
       };
 
       bot.on("message", warpoutListener);
-      this.send(`/p ${user} `);
+      this.send(`/p invite ${user} `);
       setTimeout(() => {
         bot.removeListener("message", warpoutListener);
 


### PR DESCRIPTION
Inviting the bot before doing the !warpout command will make the bot join your party and it doesn't know how to leave.

This fixes it by using /p invite rather than /p which joins players parties.