### PR TITLE
Update verifyCommand.js

### DIFF
--- a/src/discord/commands/verifyCommand.js
+++ b/src/discord/commands/verifyCommand.js
@@ -62,7 +62,7 @@ module.exports = {
         throw new HypixelDiscordChatBridgeError("This player does not have a Discord linked.");
       }
 
-      if (discordUsername !== interaction.user.username && bypassChecks !== true) {
+      if (discordUsername != interaction.user.username && bypassChecks !== true) {
         throw new HypixelDiscordChatBridgeError(
           `The player '${nickname}' has linked their Discord account to a different account ('${discordUsername}').`,
         );


### PR DESCRIPTION
Change it so users can have their discord set ingame in either format and linking will work 

eg.
discord = testuser

ingame can be set to testUser, TeStUsEr, etc any variation will work