### PR TITLE
Replaced discord-emoji-converter with node-emoji

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "chalk": "^4.1.0",
     "cheerio": "1.0.0-rc.12",
     "discord-api-types": "^0.37.55",
-    "discord-emoji-converter": "^1.2.8",
+    "node-emoji": "^2.2.0",
     "discord.js": "^14.13.0",
     "express": "^4.18.1",
     "fs-promise": "^2.0.3",

--- a/src/discord/handlers/MessageHandler.js
+++ b/src/discord/handlers/MessageHandler.js
@@ -1,5 +1,5 @@
+const emoji = require("node-emoji");
 const { uploadImage } = require("../../contracts/API/imgurAPI.js");
-const { demojify } = require("discord-emoji-converter");
 const config = require("../../../config.json");
 
 class MessageHandler {
@@ -187,9 +187,8 @@ class MessageHandler {
   }
 
   formatEmojis(content) {
-    // ? demojify() function has a bug. It throws an error when it encounters channel with emoji in its name. Example: #💬・guild-chat
     try {
-      return demojify(content);
+      return emoji.unemojify(content);
     } catch (e) {
       return content;
     }


### PR DESCRIPTION
This addresses the issue: 
`demojify() function has a bug. It throws an error when it encounters channel with emoji in its name. Example: #💬・guild-chat`

We use a new library node-emoji: https://www.npmjs.com/package/node-emoji

and it works fine so far:
![image](https://github.com/user-attachments/assets/df23c293-24d8-4998-bd0e-fc7e68427b8f)

### PLEASE TEST THANKS