### PR TITLE
Removed unnecessary dependency, Added bridge indicators for stickers, images, and attachments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "chalk": "^4.1.0",
         "cheerio": "1.0.0-rc.12",
         "discord-api-types": "^0.37.55",
-        "discord-emoji-converter": "^1.2.8",
         "discord.js": "^14.13.0",
         "express": "^4.18.1",
         "fs-promise": "^2.0.3",
@@ -3086,12 +3085,6 @@
       "version": "0.37.120",
       "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.120.tgz",
       "integrity": "sha512-7xpNK0EiWjjDFp2nAhHXezE4OUWm7s1zhc/UXXN6hnFFU8dfoPHgV0Hx0RPiCa3ILRpdeh152icc68DGCyXYIw==",
-      "license": "MIT"
-    },
-    "node_modules/discord-emoji-converter": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/discord-emoji-converter/-/discord-emoji-converter-1.2.10.tgz",
-      "integrity": "sha512-5E1zGTVRhIlgZUCnHzgZ1r2kL8SONmaCcIs8wC8d9a9lotxtyWTN2BRA6lidQohj4Yt/hW8ImuCeG2du8+82DQ==",
       "license": "MIT"
     },
     "node_modules/discord.js": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "chalk": "^4.1.0",
     "cheerio": "1.0.0-rc.12",
     "discord-api-types": "^0.37.55",
-    "discord-emoji-converter": "^1.2.8",
     "discord.js": "^14.13.0",
     "express": "^4.18.1",
     "fs-promise": "^2.0.3",


### PR DESCRIPTION
I am unsure of what happened during kathy's testing last time, but custom emojis work fine on my machine.
<img width="290" height="88" alt="image" src="https://github.com/user-attachments/assets/292cb4ae-2c47-4063-8419-654d1f802e3c" />
<img width="573" height="19" alt="image" src="https://github.com/user-attachments/assets/38290248-6aba-4fe4-8826-f359dcc8f82b" />

I added support for stickers, images, and attachments in bridge. Messages now display attachment names in brackets to indicate attached files.
<img width="647" height="683" alt="image" src="https://github.com/user-attachments/assets/bd797e7c-22e1-487e-9d25-1c24d77a90f6" />
<img width="604" height="61" alt="image" src="https://github.com/user-attachments/assets/8ad48a55-4843-4d8a-a7a6-ff45a8958462" />

