### PR TITLE
Strip emojis from discord usernames

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -88,6 +88,7 @@
     "other": {
       "messageMode": "bot",
       "messageFormat": "{chatType} > {skin} {rank} {username} {guildRank}§f: {message}",
+      "stripEmojisFromUsernames": true,
       "filterMessages": true,
       "filterWords": ["dox", "doxx", "doxed", "doxxed", "doxing", "doxxing", "doxes", "doxxes"],
       "joinMessage": true,

--- a/src/minecraft/MinecraftManager.js
+++ b/src/minecraft/MinecraftManager.js
@@ -70,6 +70,14 @@ class MinecraftManager extends CommunicationBridge {
       }
     }
 
+    if (config.discord.other.stripEmojisFromUsernames) {
+      try {
+        username = username.replace(/:[\w\-_]+:/g, '');
+      } catch (error) {
+        // Do nothing
+      }
+    }
+
     message = replaceVariables(config.minecraft.bot.messageFormat, { username, message });
 
     const chat = channel === config.discord.channels.officerChannel ? "/oc" : "/gc";


### PR DESCRIPTION
This adds a config option and regex to strip discord emojis from usernames when sending from Discord -> Minecraft