### PR TITLE
fix: duplicated mage entry

### DIFF
--- a/src/minecraft/commands/catacombsCommand.ts
+++ b/src/minecraft/commands/catacombsCommand.ts
@@ -28,7 +28,7 @@ class CatacombsCommand extends MinecraftCommand {
     this.send(
       `${username}'s Catacombs: ${formatNumber(level.level)} | Selected Class: ${profile.me.dungeons.classes.selected} | Class Average: ${formatNumber(
         profile.me.dungeons.classes.average
-      )} | Secrets Found: ${formatNumber(profile.me.dungeons.secrets)} | Classes: ${healer}H, ${mage}M, ${berserk}B, ${archer}A, ${mage}M ${tank}T`
+      )} | Secrets Found: ${formatNumber(profile.me.dungeons.secrets)} | Classes: ${healer}H, ${mage}M, ${berserk}B, ${archer}A, ${tank}T`
     );
   }
 }


### PR DESCRIPTION
simple fix for a duplicate mage entry in the !catacombs command
<img width="998" height="55" alt="image" src="https://github.com/user-attachments/assets/5b2b78cd-0de2-4ef7-80d2-ff15d302c5a9" />
