### PR TITLE
fix: messages of non-ranked players won't be sent to discord channel

### DIFF
--- a/src/minecraft/handlers/MessageHandler.ts
+++ b/src/minecraft/handlers/MessageHandler.ts
@@ -498,7 +498,7 @@ class MessageHandler {
     if (!match || !match?.groups || !match.groups.message || !match.groups.chatType || !match.groups.username) return;
 
     if (this.isDiscordMessage(match.groups.message) === false) {
-      const { chatType, rank, username, guildRank = "[Member]", message } = match.groups;
+      const { chatType, rank = "", username, guildRank = "[Member]", message } = match.groups;
       if (message.includes("replying to") && username === this.minecraft.bot.username) {
         return;
       }


### PR DESCRIPTION
When a player without a rank sends a message to the guild chat, `broadcastMessage` is executed with `rank = undefined` in https://github.com/DuckySoLucky/hypixel-discord-chat-bridge/blob/main/src/minecraft/handlers/MessageHandler.ts#L506. This causes `DiscordManager.ts` to enter the early return of `rank === undefined` in https://github.com/DuckySoLucky/hypixel-discord-chat-bridge/blob/main/src/discord/DiscordManager.ts#L117, and the message is never sent to Discord. My implementation solves this by setting the default fallback (when the player has no rank and therefore no prefix) to an empty string