### PR TITLE
fix: docker plugin loading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,6 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
 COPY . .
+RUN pnpm build
 
 ENTRYPOINT ["pnpm", "start"]


### PR DESCRIPTION
tldr docker couldn't load plugins because it doesn't know what hypixel-discord-chat-bridge/plugin-api is and now that it gets built it knows what that is